### PR TITLE
Update Dockerfile and Package.json to Bind Host to 0.0.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN yarn build
 
 EXPOSE 8080
 
-CMD ["yarn", "start", "--port", "8080"]
+CMD ["yarn", "start", "--port", "8080", "--hostname", "0.0.0.0"]

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "develop": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p 8080 -H 0.0.0.0",
     "lint": "next lint"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request updates the application to bind the host to 0.0.0.0 instead of localhost. The changes ensure the application is accessible externally when deployed in environments like Railway.

###Changes Include:

Modified the CMD in the Dockerfile to include --hostname 0.0.0.0.
Updated the start script in package.json to bind to 0.0.0.0.
Purpose: This fix resolves accessibility issues in deployment environments where localhost binds the application only to the container's internal network, making it inaccessible externally.